### PR TITLE
Remove references to neal, greedy

### DIFF
--- a/Ocean_Composites.ipynb
+++ b/Ocean_Composites.ipynb
@@ -104,7 +104,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We provide a base sampler, in this case the `SimulatedAnnealingSampler` from `neal`, a list of nodes, and a list of edges.\n",
+    "We provide a base sampler, in this case the `SimulatedAnnealingSampler` from `dwave-samplers`, a list of nodes, and a list of edges.\n",
     "The edge and node lists will come from our lattice graph."
    ]
   },
@@ -114,7 +114,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from neal import SimulatedAnnealingSampler\n",
+    "from dwave.samplers import SimulatedAnnealingSampler\n",
     "\n",
     "sampler = SimulatedAnnealingSampler()\n",
     "\n",
@@ -644,7 +644,7 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import dimod\n",
-    "from neal import SimulatedAnnealingSampler\n",
+    "from dwave.samplers import SimulatedAnnealingSampler\n",
     "from dwave.preprocessing import FixVariablesComposite\n",
     "\n",
     "# Build a BQM from a 3D lattice\n",
@@ -784,7 +784,7 @@
     "import networkx as nx\n",
     "import numpy as np\n",
     "import dimod\n",
-    "from neal import SimulatedAnnealingSampler\n",
+    "from dwave.samplers import SimulatedAnnealingSampler\n",
     "from dwave.preprocessing import FixVariablesComposite\n",
     "\n",
     "# Build a BQM from a 3D lattice\n",
@@ -836,7 +836,7 @@
    "source": [
     "Let's move on to post-processing optimization, which can often help make local improvements. The `SteepestDescentComposite` runs a greedy local optimization on a problem by taking samples from a child sampler as initial states.\n",
     "\n",
-    "The `SteepestDescentComposite` can be found in `dwave-greedy`."
+    "The `SteepestDescentComposite` can be found in `dwave-samplers`."
    ]
   },
   {
@@ -845,7 +845,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from greedy import SteepestDescentComposite"
+    "from dwave.samplers import SteepestDescentComposite"
    ]
   },
   {
@@ -921,7 +921,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from greedy import SteepestDescentComposite\n",
+    "from dwave.samplers import SteepestDescentComposite\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "num_reads = 10\n",
@@ -973,7 +973,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The lecture notebook covers several composites, exploring how they can be used a
 * [TruncateComposite](https://docs.ocean.dwavesys.com/en/stable/docs_dimod/reference/sampler_composites/composites.html#module-dimod.reference.composites.truncatecomposite)
 * [FixVariablesComposite](https://docs.ocean.dwavesys.com/en/stable/docs_preprocessing/reference/composites.html#fix-variables-composite)
 * [TrackingComposite](https://docs.ocean.dwavesys.com/en/stable/docs_dimod/reference/sampler_composites/composites.html#module-dimod.reference.composites.tracking)
-* [SteepestDescentComposite](https://docs.ocean.dwavesys.com/en/stable/docs_greedy/reference/composites.html#steepestdescentcomposite)
+* [SteepestDescentComposite](https://docs.ocean.dwavesys.com/en/stable/docs_samplers/reference.html#steepestdescentcomposite)
 
 ## Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dwave-ocean-sdk>=4.1
+dwave-ocean-sdk==6.4.0
 matplotlib==3.3.4
 jupyter


### PR DESCRIPTION
Use the modern `dwave-samplers` package instead of `dwave-neal` and `dwave-greedy`.
Update pinned version of Ocean SDK.
Update README link.